### PR TITLE
Triggers events in correct cases to avoid spamming

### DIFF
--- a/src/components/TimedContent.vue
+++ b/src/components/TimedContent.vue
@@ -87,11 +87,12 @@ export default {
       return moment.tz(this.timezone).isBetween(from, to);
     },
     toggleContent() {
+      const wasShown = this.shouldShow;
       this.shouldShow = this.shouldShowContent();
 
-      if (this.shouldShow) {
+      if (!wasShown && this.shouldShow) {
         this.$emit("show");
-      } else {
+      } else if (wasShown && !this.shouldShow) {
         this.$emit("hide");
       }
     }


### PR DESCRIPTION
Avoids event spamming only triggering the `show` event if the content was hidden before and  the `hide` event if the content was shown before.

This attempts to solve #8 