### PR TITLE
add prop to allow user used timestamp in the timezone

### DIFF
--- a/src/components/TimedContent.vue
+++ b/src/components/TimedContent.vue
@@ -24,6 +24,10 @@ export default {
       type: String,
       default: Intl.DateTimeFormat().resolvedOptions().timeZone,
       validator: isValidTimeZone
+    },
+    convertTimestamp: {
+      type: Boolean,
+      default: true
     }
   },
   data() {
@@ -59,10 +63,10 @@ export default {
   },
   computed: {
     convertedFrom() {
-      return getTimeZonedDate(this.from, this.timeZone);
+      return this.convertTimestamp ? getTimeZonedDate(this.from, this.timeZone) : this.from;
     },
     formattedTo() {
-      return getTimeZonedDate(this.to, this.timeZone);
+      return this.convertTimestamp ? getTimeZonedDate(this.to, this.timeZone) : this.to;
     },
     shouldShowContent() {
       return this.currentDate >= this.convertedFrom.getTime() && this.currentDate <= this.formattedTo.getTime();


### PR DESCRIPTION
This pr allows the user to use pass a timestamp without converting them.

Because we send a Date object, the timezone is using the locale and we want to send it as a timezone date without needing to calculate the offset. 

Fixes #49 